### PR TITLE
chore: remove 'datachain' | fix logo, chain ID

### DIFF
--- a/docker-compose/envs/common-frontend.env
+++ b/docker-compose/envs/common-frontend.env
@@ -6,9 +6,9 @@ NEXT_PUBLIC_API_BASE_PATH=/
 NEXT_PUBLIC_API_SPEC_URL=https://raw.githubusercontent.com/blockscout/blockscout-api-v2-swagger/main/swagger.yaml
 
 # NEXT_PUBLIC_STATS_API_HOST=https://stats.explorer.testnet.recall.network
-NEXT_PUBLIC_NETWORK_NAME=Recall datachain
+NEXT_PUBLIC_NETWORK_NAME=Recall network
 NEXT_PUBLIC_NETWORK_SHORT_NAME=Recall
-NEXT_PUBLIC_NETWORK_ID=5
+NEXT_PUBLIC_NETWORK_ID=2481632
 NEXT_PUBLIC_NETWORK_CURRENCY_NAME=Recall
 NEXT_PUBLIC_NETWORK_CURRENCY_SYMBOL=RECALL
 NEXT_PUBLIC_NETWORK_CURRENCY_DECIMALS=18
@@ -16,7 +16,7 @@ NEXT_PUBLIC_NETWORK_CURRENCY_DECIMALS=18
 # NEXT_PUBLIC_APP_HOST=explorer.testnet.recall.network
 # NEXT_PUBLIC_APP_PROTOCOL=https
 NEXT_PUBLIC_HOMEPAGE_CHARTS=['daily_txs']
-NEXT_PUBLIC_NETWORK_LOGO=https://raw.githubusercontent.com/recallnet/blockscout/refs/heads/hoku-localnet/apps/block_scout_web/assets/static/images/Recall_LogoLockup_Black.svg
+NEXT_PUBLIC_NETWORK_LOGO=https://raw.githubusercontent.com/recallnet/blockscout/refs/heads/master/apps/block_scout_web/assets/static/images/Recall_LogoLockup_Black.svg
 
 # NEXT_PUBLIC_VISUALIZE_API_HOST=http://visualize.explorer.testnet.recall.network
 


### PR DESCRIPTION
- The "datachain" terminology is no longer used, so this changes it to just "network"
- Updates chain ID (idk if/how this actually gets used)
- Fixes the non-existent image (it was referencing an old branch, and the image never loads)