### PR TITLE
fix: change port 5000 to 5050, enable macos use

### DIFF
--- a/docker-compose/README.md
+++ b/docker-compose/README.md
@@ -40,7 +40,7 @@ Starting an explorer runs 10 Docker containers (plus [`caddy`](https://hub.docke
 - Redis database of the latest version.
 - Blockscout backend with api at /api path.
 - Nginx proxy to bind backend, frontend and microservices.
-- Blockscout explorer at http://localhost:5000.
+- Blockscout explorer at http://localhost:5050.
 
 and 5 containers for microservices:
 

--- a/docker-compose/envs/localnet.env
+++ b/docker-compose/envs/localnet.env
@@ -9,7 +9,7 @@ ETHEREUM_JSONRPC_FALLBACK_HTTP_URL=http://host.docker.internal:8745
 # frontend
 NEXT_PUBLIC_API_HOST=localhost
 NEXT_PUBLIC_API_PROTOCOL=http
-NEXT_PUBLIC_API_PORT=5000
+NEXT_PUBLIC_API_PORT=5050
 NEXT_PUBLIC_API_WEBSOCKET_PROTOCOL=ws
 NEXT_PUBLIC_STATS_API_HOST=http://localhost:8080
 NEXT_PUBLIC_APP_HOST=localhost
@@ -18,7 +18,7 @@ NEXT_PUBLIC_VISUALIZE_API_HOST=http://localhost:8081
 NEXT_PUBLIC_IS_TESTNET=true
 
 # stats
-STATS__BLOCKSCOUT_API_URL=http://host.docker.internal:5000
+STATS__BLOCKSCOUT_API_URL=http://host.docker.internal:5050
 
 # user ops indexer
 USER_OPS_INDEXER__INDEXER__RPC_URL=ws://host.docker.internal:8645 # eth api facade

--- a/docker-compose/proxy/default.conf.template
+++ b/docker-compose/proxy/default.conf.template
@@ -5,7 +5,7 @@ map $http_upgrade $connection_upgrade {
 }
 
 server {
-    listen       5000;
+    listen       5050;
     server_name  localhost;
     proxy_http_version 1.1;
 

--- a/docker-compose/services/nginx.yml
+++ b/docker-compose/services/nginx.yml
@@ -10,8 +10,8 @@ services:
       BACK_PROXY_PASS: http://block-explorer-backend:4000
       FRONT_PROXY_PASS: http://block-explorer-frontend:3000
     ports:
-      - target: 5000
-        published: 5000
+      - target: 5050
+        published: 5050
       - target: 8080
         published: 8080
       - target: 8081

--- a/docker-compose/workdir/caddy/Caddyfile
+++ b/docker-compose/workdir/caddy/Caddyfile
@@ -1,5 +1,5 @@
 explorer.testnet.recall.network {
-  reverse_proxy block-explorer-proxy:5000
+  reverse_proxy block-explorer-proxy:5050
   tls infra@3box.io
 }
 stats.explorer.testnet.recall.network {


### PR DESCRIPTION
Mac OS seems to be using port 5000 on many of our dev machines.  This prevents our team from deploying the explorer locally against a localnet instance. 

This changes the nextjs app port to 5050, which (hopefully) allows us all to develop against a local deployment