### PR TITLE
feat: update the frontend to our custom image

### DIFF
--- a/docker-compose/services/frontend.yml
+++ b/docker-compose/services/frontend.yml
@@ -1,6 +1,6 @@
 services:
   frontend:
-    image: ghcr.io/blockscout/frontend:${FRONTEND_DOCKER_TAG:-latest}
+    image: textilemachine/blockscout-frontend:${FRONTEND_DOCKER_TAG:-latest}
     pull_policy: always
     platform: linux/amd64
     restart: always


### PR DESCRIPTION
This updates the docker-compose files to use our custom frontend image.  The image is currently being published via a github action in the frontend repo: https://github.com/recallnet/blockscout-frontend  

The docker image is located here: https://hub.docker.com/repositories/textilemachine

I tested this by running a sandbox network locally.  
